### PR TITLE
fix: Allow for chaining multiple displays

### DIFF
--- a/marquee/Settings.h
+++ b/marquee/Settings.h
@@ -102,6 +102,10 @@ String OctoAuthPass = "";      // only used with haproxy or basic auth (only nee
 String BitcoinCurrencyCode = "NONE";  // Change to USD, GBD, EUR, or NONE -- this can be managed in the Web Interface
 
 boolean ENABLE_OTA = true;  // this will allow you to load firmware to the device over WiFi (see OTA for ESP8266)
+
+const int numberOfHorizontalDisplays = 4;
+const int numberOfVerticalDisplays = 1;
+
 //******************************
 // End Settings
 //******************************

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -50,8 +50,6 @@ int8_t getWifiQuality();
 
 // LED Settings
 const int offset = 1;
-const int numberOfHorizontalDisplays = 4;
-const int numberOfVerticalDisplays = 1;
 int refresh = 0;
 String message = "hello";
 int spacer = 1;  // dots between letters
@@ -182,17 +180,13 @@ void setup() {
 
   // initialize dispaly
   matrix.setIntensity(0); // Use a value between 0 and 15 for brightness
-  matrix.setRotation(0,3);
-  matrix.setRotation(1,3);
-  matrix.setRotation(2,3);
-  matrix.setRotation(3,3);
 
+  int maxPos = numberOfHorizontalDisplays * numberOfVerticalDisplays;
+  for (int i = 0; i < maxPos; i++) {
+    matrix.setRotation(i,3);
+    matrix.setPosition(i, maxPos - i - 1, 0);
+  }
 
-// Adjust to your own needs
-  matrix.setPosition(0, 3, 0); // The first display is at <0, 7>
-  matrix.setPosition(1, 2, 0); // The second display is at <1, 0>
-  matrix.setPosition(2, 1, 0); // The third display is at <2, 0>
-  matrix.setPosition(3, 0, 0); // And the last display is at <3, 0>
   Serial.println("matrix created");
   matrix.fillScreen(LOW); // show black
   centerPrint("hello");


### PR DESCRIPTION
I wanted to have two of the 4 screen displays chained. This change moves the number of vertical and horizontal to settings and then does the initialization of position and rotation based on the numbers rather than a fixed number of times.