### PR TITLE
Update marquee.ino

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -110,7 +110,7 @@ String CHANGE_FORM2 = "<p><input name='isPM' class='w3-check w3-margin-top' type
                       "<p><label>Marquee Message (up to 60 chars)</label><input class='w3-input w3-border w3-margin-bottom' type='text' name='marqueeMsg' value='%MSG%' maxlength='60'></p>"
                       "<p><label>Start Time </label><input name='startTime' type='time' value='%STARTTIME%'></p>"
                       "<p><label>End Time </label><input name='endTime' type='time' value='%ENDTIME%'></p>"
-                      "<p>Display Brightness <input class='w3-border w3-margin-bottom' name='ledintensity' type='number' min='1' max='15' value='%INTENSITYOPTIONS%'></p>"
+                      "<p>Display Brightness <input class='w3-border w3-margin-bottom' name='ledintensity' type='number' min='0' max='15' value='%INTENSITYOPTIONS%'></p>"
                       "<p>Display Scroll Speed <select class='w3-option w3-padding' name='scrollspeed'>%SCROLLOPTIONS%</select></p>"
                       "<p>Minutes Between Refresh Data <select class='w3-option w3-padding' name='refresh'>%OPTIONS%</select></p>"
                       "<p>Minutes Between Scrolling Data <input class='w3-border w3-margin-bottom' name='refreshDisplay' type='number' min='1' max='10' value='%REFRESH_DISPLAY%'></p>";


### PR DESCRIPTION
It seems to me that the library for ledmatrix allows brightness values from 0 to 15 (it is even commented in line 178 of marquee.ino). However the web interface limits the value to 1-15. I do not see the reason for the limitation and would love to use the clock in my bedroom but it's simply too bright at value 1. This is my first proposition on github so I hope it is okay and sorry if I made any mistakes.