### PR TITLE
Added weather features: wind direction (to wind speed), barometric pressure, and daily high/low temperatures

### DIFF
--- a/marquee/OpenWeatherMapClient.cpp
+++ b/marquee/OpenWeatherMapClient.cpp
@@ -114,6 +114,8 @@ void OpenWeatherMapClient::updateWeather() {
     weathers[inx].icon = (const char*)root["list"][inx]["weather"][0]["icon"];
     weathers[inx].pressure = (const char*)root["list"][inx]["main"]["pressure"];
     weathers[inx].direction = (const char*)root["list"][inx]["wind"]["deg"];
+    weathers[inx].high = (const char*)root["list"][inx]["main"]["temp_max"];
+    weathers[inx].low = (const char*)root["list"][inx]["main"]["temp_min"];
 
     if (units == "metric") {
       // convert to kph from m/s
@@ -121,6 +123,12 @@ void OpenWeatherMapClient::updateWeather() {
       weathers[inx].wind = String(f);
     }
 
+    if (units != "metric")
+    {
+      float p = (weathers[inx].pressure.toFloat() * 0.0295301); //convert millibars to inches
+      weathers[inx].pressure = String(p);
+    }
+    
     Serial.println("lat: " + weathers[inx].lat);
     Serial.println("lon: " + weathers[inx].lon);
     Serial.println("dt: " + weathers[inx].dt);
@@ -234,6 +242,16 @@ String OpenWeatherMapClient::getDescription(int index) {
 String OpenWeatherMapClient::getPressure(int index)
 {
   return weathers[index].pressure;
+}
+
+String OpenWeatherMapClient::getHigh(int index)
+{
+  return weathers[index].high;
+}
+
+String OpenWeatherMapClient::getLow(int index)
+{
+  return weathers[index].low;
 }
 
 String OpenWeatherMapClient::getIcon(int index) {

--- a/marquee/OpenWeatherMapClient.cpp
+++ b/marquee/OpenWeatherMapClient.cpp
@@ -112,6 +112,8 @@ void OpenWeatherMapClient::updateWeather() {
     weathers[inx].weatherId = (const char*)root["list"][inx]["weather"][0]["id"];
     weathers[inx].description = (const char*)root["list"][inx]["weather"][0]["description"];
     weathers[inx].icon = (const char*)root["list"][inx]["weather"][0]["icon"];
+    weathers[inx].pressure = (const char*)root["list"][inx]["main"]["pressure"];
+    weathers[inx].direction = (const char*)root["list"][inx]["wind"]["deg"];
 
     if (units == "metric") {
       // convert to kph from m/s
@@ -128,6 +130,7 @@ void OpenWeatherMapClient::updateWeather() {
     Serial.println("humidity: " + weathers[inx].humidity);
     Serial.println("condition: " + weathers[inx].condition);
     Serial.println("wind: " + weathers[inx].wind);
+    Serial.println("direction: " + weathers[inx].direction);
     Serial.println("weatherId: " + weathers[inx].weatherId);
     Serial.println("description: " + weathers[inx].description);
     Serial.println("icon: " + weathers[inx].icon);
@@ -206,6 +209,16 @@ String OpenWeatherMapClient::getWind(int index) {
   return weathers[index].wind;
 }
 
+String OpenWeatherMapClient::getDirection(int index)
+{
+  return weathers[index].direction;
+}
+
+String OpenWeatherMapClient::getDirectionRounded(int index)
+{
+  return roundValue(getDirection(index));
+}
+
 String OpenWeatherMapClient::getWindRounded(int index) {
   return roundValue(getWind(index));
 }
@@ -216,6 +229,11 @@ String OpenWeatherMapClient::getWeatherId(int index) {
 
 String OpenWeatherMapClient::getDescription(int index) {
   return weathers[index].description;
+}
+
+String OpenWeatherMapClient::getPressure(int index)
+{
+  return weathers[index].pressure;
 }
 
 String OpenWeatherMapClient::getIcon(int index) {

--- a/marquee/OpenWeatherMapClient.h
+++ b/marquee/OpenWeatherMapClient.h
@@ -51,6 +51,8 @@ private:
     String error;
     String pressure;
     String direction;
+    String high;
+    String low;
   } weather;
 
   weather weathers[5];
@@ -79,6 +81,8 @@ public:
   String getDirection(int index);
   String getDirectionRounded(int index);
   String getPressure(int index);
+  String getHigh(int index);
+  String getLow(int index);
   String getWeatherId(int index);
   String getDescription(int index);
   String getIcon(int index);

--- a/marquee/OpenWeatherMapClient.h
+++ b/marquee/OpenWeatherMapClient.h
@@ -49,6 +49,8 @@ private:
     String icon;
     boolean cached;
     String error;
+    String pressure;
+    String direction;
   } weather;
 
   weather weathers[5];
@@ -74,6 +76,9 @@ public:
   String getCondition(int index);
   String getWind(int index);
   String getWindRounded(int index);
+  String getDirection(int index);
+  String getDirectionRounded(int index);
+  String getPressure(int index);
   String getWeatherId(int index);
   String getDescription(int index);
   String getIcon(int index);


### PR DESCRIPTION
I added some additional weather functionality:
1) Added the wind direction to be displayed along with the wind speed. 
2) Added barometric pressure with the option to display or not display the pressure via a check mark on the configuration page. Baro pressure is displayed in millibars (mb) if Use Metric is checked. It's displayed in inches of mercury if Use Metric is unchecked. 
3) Added a display of daily high/daily low temperatures. Again, Celsius vs Fahrenheit is dependent on whether Use Metric is checked or not.
(There was a feature request on the main branch to add a user check mark to specify Celsius or Fahrenheit for temperature, independent of Metric units for other measurements. I can add this feature in a future update, time-permitting.

These weather features come from the existing weather requests already being made by the marquee. I just take extra data from the JSON fields to get the wind direction, baro pressure, and daily high/low temperatures. 

I've tested these changes on my marquee for the last few weeks and have had no issues with them. Let me know if you have any questions. 
-Brandon 