### PR TITLE
Add support for building with platformio

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,25 @@
+[platformio]
+src_dir = marquee
+lib_dir = marquee/libs
+src_filter = -lib
+upload_port = /dev/ttyUSB*
+default_envs = nodemcuv2
+
+[env:nodemcuv2]
+framework = arduino
+platform = espressif8266
+board = nodemcuv2
+
+[env:wemos]
+framework = arduino
+platform = espressif8266
+board = d1_mini
+
+
+
+lib_deps =
+    tzapu/WiFiManager
+    PaulStoffregen/Time
+    adafruit/Adafruit-GFX-Library
+    markruys/arduino-Max72xxPanel
+    squix78/json-streaming-parser


### PR DESCRIPTION
I've added basic configuration that would allow import and build this project using Platformio (from visual studio code for example).
You can switch profiles by changing default_envs variable - between `nodemcu` and `wemos`.

I'll add static versions later, to avoid error builds when signatures of this libraries would change.