### PR TITLE
Show time and temp on the main screen on single (4 panel) unit

### DIFF
--- a/marquee/Settings.h
+++ b/marquee/Settings.h
@@ -65,6 +65,7 @@ String marqueeMessage = "";
 boolean IS_METRIC = false; // false = Imperial and true = Metric
 boolean IS_24HOUR = false; // 23:00 millitary 24 hour clock
 boolean IS_PM = true; // Show PM indicator on Clock when in AM/PM mode
+boolean IS_ALTERNATE = false; // Show PM indicator on Clock when in AM/PM mode
 const int WEBSERVER_PORT = 80; // The port you can access this device on over HTTP
 const boolean WEBSERVER_ENABLED = true;  // Device will provide a web interface via http://[ip]:[port]/
 boolean IS_BASIC_AUTH = false;  // Use Basic Authorization for Configuration security on Web Interface


### PR DESCRIPTION
Hello,

This alternates every 10 seconds between the time and temp on the main screen. Only displays the config menu if less than 8 panels in use. Not in the best location though. 

Let me know if you have any questions.

Sorry about the Settings.h. I can try to do another pull request if you're interested in the feature to clean that up. I only added one line there # 68.

Thank you,
Matt