### PR TITLE
Replace more chars in cleanText

### DIFF
--- a/marquee/NewsApiClient.cpp
+++ b/marquee/NewsApiClient.cpp
@@ -171,6 +171,10 @@ String NewsApiClient::cleanText(String text) {
   text.replace("î", "i");
   text.replace("ï", "i");
   text.replace("ô", "o");
+  text.replace("ó", "o");
+  text.replace("ò", "o");
+  text.replace("Ó", "O");
+  text.replace("Ò", "O");
   text.replace("…", "...");
   text.replace("–", "-");
   text.replace("Â", "A");
@@ -194,5 +198,7 @@ String NewsApiClient::cleanText(String text) {
   text.replace("ß", "ss");
   text.replace("»", "'");
   text.replace("«", "'");
+  text.replace(" ", " "); // Non-breaking whitespace
+  
   return text;
 }


### PR DESCRIPTION
I saw some characters in news headlines, that couldn't be rendered properly, so I added them to the replacement list.